### PR TITLE
feat(search): Add search API documentation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -62,6 +62,15 @@ export default defineConfig({
                         ]
                     },
                     {
+                        text: "Search",
+                        link: "/apis/search/",
+                        items: [
+                            {text: "Available providers", link: "/apis/search/#available-models"},
+                            {text: "Pricing", link: "/apis/search/#pricing"},
+                            {text: "Usage", link: "/apis/search/usage"},
+                        ]
+                    },
+                    {
                         text: "x402 payments",
                         link: "/apis/x402",
                     },

--- a/apis/search/index.md
+++ b/apis/search/index.md
@@ -1,7 +1,9 @@
 # Web Search
 
-LibertAI offers web search models with competitive pricing.\
+LibertAI offers web search models with competitive pricing.
 These models are currently available through [LiberClaw.ai](https://liberclaw.ai) and are not directly accessible via the API.
+
+You can find usage examples in various languages [here](./usage.md).
 
 <script setup>
 import { ref, onMounted } from 'vue'
@@ -146,7 +148,7 @@ code {
 }
 </style>
 
-## Available Search Providers
+## Available Models
 
 <div v-if="modelsData" class="models-list">
   <div v-for="model in modelsData.models" :key="model.id" class="model-card">

--- a/apis/search/usage.md
+++ b/apis/search/usage.md
@@ -1,0 +1,322 @@
+# Usage
+
+The search API provides the following endpoints:
+- `POST /search`: Search across multiple engines (Google, Bing, DuckDuckGo)
+- `POST /fetch`: Fetch and clean content from a URL
+- `GET /health`: Health check endpoint
+- `GET /workers`: List available workers (no auth required)
+
+## API Reference
+
+### POST `/search`
+
+Search the web across multiple engines simultaneously. Results are aggregated, deduplicated by URL, and ranked by cross-engine consensus.
+
+**Request:**
+
+```json
+{
+  "query": "rust programming language",
+  "engines": ["google", "bing", "duckduckgo"],
+  "max_results": 10,
+  "search_type": "web"
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `query` | Yes | | Search query string |
+| `engines` | No | `["google", "bing", "duckduckgo"]` | Engines to query: `google`, `bing`, `duckduckgo` |
+| `max_results` | No | `10` | Maximum results per engine |
+| `search_type` | No | `"web"` | Type of search: `web`, `news`, `images` |
+
+**Response:**
+
+```json
+{
+  "results": [
+    {
+      "title": "The Rust Programming Language",
+      "url": "https://doc.rust-lang.org/book/",
+      "snippet": "Official documentation for the Rust programming language...",
+      "engine": "google",
+      "rank": 1,
+      "found_in": ["google", "bing"],
+      "search_type": "web"
+    }
+  ],
+  "meta": {
+    "duration_ms": 1234,
+    "engines_used": ["google", "bing", "duckduckgo"],
+    "engines_failed": [],
+    "engine_errors": []
+  }
+}
+```
+
+### POST `/fetch`
+
+Fetch a URL and return its cleaned readable text content.
+
+**Request:**
+
+```json
+{
+  "url": "https://example.com/article"
+}
+```
+
+**Response:**
+
+```json
+{
+  "url": "https://example.com/article",
+  "title": "Article Title",
+  "content": "The cleaned article text content...",
+  "word_count": 1234
+}
+```
+
+:::tabs
+
+== Shell
+```sh
+# Web Search
+curl -X POST https://search.libertai.io/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "query": "rust programming language",
+    "engines": ["google", "bing"],
+    "max_results": 10
+  }'
+
+# News Search
+curl -X POST https://search.libertai.io/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "query": "artificial intelligence",
+    "engines": ["google", "bing"],
+    "search_type": "news",
+    "max_results": 5
+  }'
+
+# Image Search
+curl -X POST https://search.libertai.io/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "query": "rust programming logo",
+    "engines": ["google"],
+    "search_type": "images",
+    "max_results": 5
+  }'
+
+# Fetch URL Content
+curl -X POST https://search.libertai.io/fetch \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "url": "https://doc.rust-lang.org/book/"
+  }'
+```
+
+== Python
+```python
+import requests
+
+# Web Search
+response = requests.post(
+    "https://search.libertai.io/search",
+    headers={
+        "Authorization": "Bearer YOUR_API_KEY",
+        "Content-Type": "application/json"
+    },
+    json={
+        "query": "rust programming language",
+        "engines": ["google", "bing", "duckduckgo"],
+        "max_results": 10
+    }
+)
+
+results = response.json()
+for result in results["results"]:
+    print(f"{result['title']} - {result['url']}")
+    print(f"Found in: {result['found_in']}")
+    print()
+
+# News Search
+news_response = requests.post(
+    "https://search.libertai.io/search",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    json={
+        "query": "artificial intelligence",
+        "engines": ["google", "bing"],
+        "search_type": "news"
+    }
+)
+
+# Fetch content
+fetch_response = requests.post(
+    "https://search.libertai.io/fetch",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    json={"url": "https://doc.rust-lang.org/book/"}
+)
+
+content = fetch_response.json()
+print(f"Title: {content['title']}")
+print(f"Word count: {content['word_count']}")
+```
+
+== TypeScript
+```ts
+import fetch from 'node-fetch';
+
+// Web Search
+const response = await fetch('https://search.libertai.io/search', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_API_KEY',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    query: 'rust programming language',
+    engines: ['google', 'bing'],
+    max_results: 10
+  })
+});
+
+const data = await response.json();
+for (const result of data.results) {
+  console.log(`${result.title} - ${result.url}`);
+  console.log(`Found in engines: ${result.found_in.join(', ')}`);
+}
+
+// News Search
+const newsResponse = await fetch('https://search.libertai.io/search', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_API_KEY',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    query: 'artificial intelligence',
+    engines: ['google', 'bing'],
+    search_type: 'news'
+  })
+});
+
+// Fetch content
+const fetchResponse = await fetch('https://search.libertai.io/fetch', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer YOUR_API_KEY',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    url: 'https://doc.rust-lang.org/book/'
+  })
+});
+
+const content = await fetchResponse.json();
+console.log(content.content);
+```
+
+:::
+
+## Advanced Examples
+
+### Cross-Engine Consensus Scoring
+
+Results appearing in multiple engines are ranked higher. Use the `found_in` array to implement custom scoring:
+
+```python
+import requests
+
+response = requests.post(
+    "https://search.libertai.io/search",
+    json={"query": "rust programming", "engines": ["google", "bing", "duckduckgo"]}
+)
+
+for result in response.json()["results"]:
+    # Higher score for results found in multiple engines
+    consensus_score = len(result["found_in"])
+    print(f"{consensus_score}/3 engines: {result['title']}")
+```
+
+### Error Handling
+
+The API returns partial results when some engines fail:
+
+```python
+import requests
+from requests.exceptions import RequestException
+
+try:
+    response = requests.post(
+        "https://search.libertai.io/search",
+        json={"query": "test", "engines": ["google", "bing"]},
+        timeout=30
+    )
+    
+    if response.status_code == 503:
+        print("All engines failed")
+    else:
+        data = response.json()
+        print(f"Engines used: {data['meta']['engines_used']}")
+        print(f"Engines failed: {data['meta']['engines_failed']}")
+        
+except RequestException as e:
+    print(f"Request failed: {e}")
+```
+
+### Image Search with Metadata
+
+```javascript
+const response = await fetch('https://search.libertai.io/search', {
+  method: 'POST',
+  headers: { 'Authorization': 'Bearer YOUR_API_KEY' },
+  body: JSON.stringify({
+    query: 'rust programming logo',
+    engines: ['google'],
+    search_type: 'images',
+    max_results: 5
+  })
+});
+
+const data = await response.json();
+for (const result of data.results) {
+  console.log({
+    title: result.title,
+    thumbnail: result.thumbnail_url,
+    fullSize: result.image_url,
+    dimensions: `${result.width}x${result.height}`
+  });
+}
+```
+
+## Rate Limits
+
+- **Timeout:** 10 seconds per engine (engines queried in parallel)
+- **Partial results:** If some engines succeed and others fail, you receive results from successful engines
+- **Error details:** Check `meta.engine_errors` for per-engine failure reasons
+
+## Supported Search Types
+
+| Search Type | Google | Bing | DuckDuckGo |
+|-------------|--------|------|-------------|
+| `web` | Yes | Yes | Yes |
+| `news` | Yes | Yes | No |
+| `images` | Yes | Yes | No |
+
+### Response Fields by Search Type
+
+| Field | Present for | Description |
+|-------|------------|-------------|
+| `thumbnail_url` | `images` | Thumbnail image URL |
+| `image_url` | `images` | Full-size image URL |
+| `width` | `images` | Image width in pixels |
+| `height` | `images` | Image height in pixels |
+| `published_at` | `news` | Publication date |
+| `source` | `news` | News source name |


### PR DESCRIPTION
## Summary

Added comprehensive documentation for the new Search API:

- **apis/search/index.md** - Live model listing (Google, Bing, DuckDuckGo) with pricing fetched from Aleph registry
- **apis/search/usage.md** - API reference, endpoints, and usage examples in Shell/Python/TypeScript
- **Sidebar update** - Added Search section under APIs

## Changes

- Dynamic pricing table showing $0.002-0.003 per query depending on provider
- API reference for `POST /search` and `POST /fetch` endpoints
- Code examples for web search, news search, and image search
- Search type support matrix (web/news/images per engine)
- Deprecated models section (ready for future use)

## Testing

Tested against live API at `search.libertai.io` - Bing returns results successfully.,