### PR TITLE
feat: document embeddings API (bge-m3)

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -82,6 +82,15 @@ export default defineConfig({
                         ]
                     },
                     {
+                        text: "Embeddings",
+                        link: "/apis/embeddings/",
+                        items: [
+                            {text: "Available models", link: "/apis/embeddings/#available-models"},
+                            {text: "Pricing", link: "/apis/embeddings/#pricing"},
+                            {text: "Usage", link: "/apis/embeddings/usage"},
+                        ]
+                    },
+                    {
                         text: "Search",
                         link: "/apis/search/",
                         items: [

--- a/.vitepress/theme/components/ModelsPricing.vue
+++ b/.vitepress/theme/components/ModelsPricing.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { z } from 'zod'
 
 const props = defineProps<{
-  category: 'text' | 'image' | 'search'
+  category: 'text' | 'image' | 'search' | 'embedding'
 }>()
 
 const TextCapsSchema = z.object({
@@ -14,6 +14,11 @@ const TextCapsSchema = z.object({
   vision: z.boolean(),
 }).optional()
 
+const EmbeddingCapsSchema = z.object({
+  context_window: z.number(),
+  dimensions: z.number(),
+}).optional()
+
 const ModelSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -22,6 +27,7 @@ const ModelSchema = z.object({
     text: TextCapsSchema,
     image: z.boolean().optional(),
     search: z.boolean().optional(),
+    embedding: EmbeddingCapsSchema,
   }),
   pricing: z.object({
     text: z.object({
@@ -30,6 +36,9 @@ const ModelSchema = z.object({
     }).optional(),
     image: z.number().optional(),
     search: z.number().optional(),
+    embedding: z.object({
+      price_per_million_input_tokens: z.number(),
+    }).optional(),
   }),
 })
 
@@ -92,6 +101,10 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
           <span v-if="m.capabilities.text.reasoning" class="mp-cap" title="Reasoning supported">🧠 reasoning</span>
           <span v-if="m.capabilities.text.tee" class="mp-cap" title="Running in a Trusted Execution Environment">🔒 TEE</span>
         </div>
+        <div v-else-if="m.capabilities.embedding" class="mp-caps">
+          <span class="mp-ctx">{{ m.capabilities.embedding.context_window.toLocaleString() }} context window</span>
+          <span class="mp-cap" title="Embedding vector dimensions">📐 {{ m.capabilities.embedding.dimensions }} dimensions</span>
+        </div>
       </div>
     </div>
 
@@ -103,6 +116,9 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
         </thead>
         <thead v-else-if="category === 'image'">
           <tr><th>Model</th><th>Price per image</th></tr>
+        </thead>
+        <thead v-else-if="category === 'embedding'">
+          <tr><th>Model</th><th>Price per 1M input tokens</th></tr>
         </thead>
         <thead v-else>
           <tr><th>Engine</th><th>Price per query</th></tr>
@@ -116,6 +132,9 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
             </template>
             <template v-else-if="category === 'image'">
               <td>{{ m.pricing.image != null ? `$${m.pricing.image.toFixed(4)}` : '—' }}</td>
+            </template>
+            <template v-else-if="category === 'embedding'">
+              <td>{{ m.pricing.embedding != null ? `$${m.pricing.embedding.price_per_million_input_tokens.toFixed(2)} / 1M tokens` : '—' }}</td>
             </template>
             <template v-else>
               <td>{{ m.pricing.search != null ? `$${m.pricing.search.toFixed(4)}` : '—' }}</td>

--- a/apis/embeddings/index.md
+++ b/apis/embeddings/index.md
@@ -1,0 +1,15 @@
+# Embeddings
+
+LibertAI offers embedding models that turn text into vectors — for semantic search, retrieval-augmented generation
+(RAG), clustering, and classification. The API is OpenAI-compatible (`/v1/embeddings`).
+
+- New here? [Usage](./usage.md) covers single and batched embedding calls.
+
+<ModelsPricing category="embedding" />
+
+## See also
+
+- [Usage examples](./usage.md) — single & batch inputs, OpenAI SDKs
+- [x402 payments](/apis/x402) — pay per request without an API key
+- [Trust model & TEE](/concepts/trust-model) — what the 🔒 flag guarantees
+- [Architecture](/architecture)

--- a/apis/embeddings/usage.md
+++ b/apis/embeddings/usage.md
@@ -1,0 +1,93 @@
+# Usage
+
+Our embedding models expose the OpenAI-compatible [Embeddings API](https://platform.openai.com/docs/api-reference/embeddings):
+- `/v1/embeddings`: create an embedding vector for the given input
+
+This means you can use our embedding models with any of [the OpenAI SDKs](https://platform.openai.com/docs/libraries#install-an-official-sdk) or with any framework that supports custom OpenAI-compatible embedding endpoints.
+
+> 💡 Embeddings are billed on **input tokens only** — there are no output tokens.
+
+## Examples
+
+### Create an embedding
+
+:::tabs
+
+== Shell
+```sh
+curl -X POST https://api.libertai.io/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "bge-m3",
+    "input": "The quick brown fox jumps over the lazy dog"
+  }'
+```
+
+== Python
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.libertai.io/v1",
+    api_key="YOUR_API_KEY",
+)
+
+response = client.embeddings.create(
+    model="bge-m3",
+    input="The quick brown fox jumps over the lazy dog",
+)
+
+print(len(response.data[0].embedding))  # vector dimensions
+```
+
+== TypeScript
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: 'https://api.libertai.io/v1',
+  apiKey: "YOUR_API_KEY",
+});
+
+const response = await client.embeddings.create({
+  model: "bge-m3",
+  input: "The quick brown fox jumps over the lazy dog",
+});
+
+console.log(response.data[0].embedding.length);
+```
+
+:::
+
+### Batch inputs
+
+Pass a list of strings to embed many texts in a single request:
+
+:::tabs
+
+== Shell
+```sh
+curl -X POST https://api.libertai.io/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "bge-m3",
+    "input": ["first document", "second document", "third document"]
+  }'
+```
+
+== Python
+```python
+texts = ["first document", "second document", "third document"]
+
+response = client.embeddings.create(model="bge-m3", input=texts)
+
+for item in response.data:
+    print(item.index, len(item.embedding))
+```
+
+:::
+
+The response follows the OpenAI format: a `data` array of `{ "embedding": [...], "index": n }` objects, plus a
+`usage` object reporting `prompt_tokens` (and `total_tokens`, equal — embeddings have no completion tokens).

--- a/apis/index.md
+++ b/apis/index.md
@@ -1,12 +1,13 @@
 # APIs
 
-LibertAI exposes OpenAI- and Anthropic-compatible APIs for text, image, and web search. Each API is documented with
-its own models, pricing, and usage examples.
+LibertAI exposes OpenAI- and Anthropic-compatible APIs for text, image, embeddings, and web search. Each API is
+documented with its own models, pricing, and usage examples.
 
 | API | What it does | OpenAI-compat | x402-eligible |
 |-----|--------------|:-------------:|:-------------:|
 | [Text](text/index.md) | Chat completions, completions, Anthropic Messages, function calling, vision, streaming | ✅ | ✅ |
 | [Image](image/index.md) | Stable Diffusion WebUI and OpenAI images endpoints | ✅ | ✅ |
+| [Embeddings](embeddings/index.md) | Text embeddings for semantic search, RAG, clustering | ✅ | ✅ |
 | [Search](search/index.md) | Multi-engine search + URL fetch for RAG | — | ✅ |
 
 ## Authentication


### PR DESCRIPTION
## Summary
Documents the **embeddings API** and adds bge-m3 to the model/pricing listing.

## Changes
- New `apis/embeddings/` section: `index.md` (intro + `<ModelsPricing category="embedding" />`) and `usage.md` (single + batch `/v1/embeddings` examples in Shell/Python/TS).
- `ModelsPricing.vue`: support the `embedding` category — schema (`EmbeddingCapability` with `context_window`/`dimensions`, `EmbeddingPricing`), capability chips, and a "Price per 1M input tokens" pricing table.
- `apis/index.md`: add an Embeddings row to the API table.
- `.vitepress/config.mts`: add the Embeddings sidebar section.

Model list/pricing render live from the Aleph `LTAI_PRICING` aggregate, so bge-m3 appears automatically once its entry (with `capabilities.embedding` + `pricing.embedding`) is added there.

## Verification
- `vitepress build .` ✓ (build complete, no errors)
