### PR TITLE
docs: add Audio (TTS) API

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -91,6 +91,15 @@ export default defineConfig({
                         ]
                     },
                     {
+                        text: "Audio",
+                        link: "/apis/audio/",
+                        items: [
+                            {text: "Available models", link: "/apis/audio/#available-models"},
+                            {text: "Pricing", link: "/apis/audio/#pricing"},
+                            {text: "Usage", link: "/apis/audio/usage"},
+                        ]
+                    },
+                    {
                         text: "Search",
                         link: "/apis/search/",
                         items: [

--- a/.vitepress/theme/components/ModelsPricing.vue
+++ b/.vitepress/theme/components/ModelsPricing.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { z } from 'zod'
 
 const props = defineProps<{
-  category: 'text' | 'image' | 'search' | 'embedding'
+  category: 'text' | 'image' | 'search' | 'embedding' | 'audio'
 }>()
 
 const TextCapsSchema = z.object({
@@ -19,6 +19,11 @@ const EmbeddingCapsSchema = z.object({
   dimensions: z.number(),
 }).optional()
 
+const AudioCapsSchema = z.object({
+  languages: z.array(z.string()),
+  voices: z.array(z.string()),
+}).optional()
+
 const ModelSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -28,6 +33,7 @@ const ModelSchema = z.object({
     image: z.boolean().optional(),
     search: z.boolean().optional(),
     embedding: EmbeddingCapsSchema,
+    audio: AudioCapsSchema,
   }),
   pricing: z.object({
     text: z.object({
@@ -38,6 +44,9 @@ const ModelSchema = z.object({
     search: z.number().optional(),
     embedding: z.object({
       price_per_million_input_tokens: z.number(),
+    }).optional(),
+    audio: z.object({
+      price_per_million_input_characters: z.number(),
     }).optional(),
   }),
 })
@@ -105,6 +114,10 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
           <span class="mp-ctx">{{ m.capabilities.embedding.context_window.toLocaleString() }} context window</span>
           <span class="mp-cap" title="Embedding vector dimensions">📐 {{ m.capabilities.embedding.dimensions }} dimensions</span>
         </div>
+        <div v-else-if="m.capabilities.audio" class="mp-caps">
+          <span class="mp-ctx">{{ m.capabilities.audio.languages.length }} languages</span>
+          <span class="mp-cap" title="Built-in voices">🗣️ {{ m.capabilities.audio.voices.length }} voices</span>
+        </div>
       </div>
     </div>
 
@@ -119,6 +132,9 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
         </thead>
         <thead v-else-if="category === 'embedding'">
           <tr><th>Model</th><th>Price per 1M input tokens</th></tr>
+        </thead>
+        <thead v-else-if="category === 'audio'">
+          <tr><th>Model</th><th>Price per 1M input characters</th></tr>
         </thead>
         <thead v-else>
           <tr><th>Engine</th><th>Price per query</th></tr>
@@ -135,6 +151,9 @@ const noModels = computed(() => !loading.value && !error.value && models.value.l
             </template>
             <template v-else-if="category === 'embedding'">
               <td>{{ m.pricing.embedding != null ? `$${m.pricing.embedding.price_per_million_input_tokens.toFixed(2)} / 1M tokens` : '—' }}</td>
+            </template>
+            <template v-else-if="category === 'audio'">
+              <td>{{ m.pricing.audio != null ? `$${m.pricing.audio.price_per_million_input_characters.toFixed(2)} / 1M characters` : '—' }}</td>
             </template>
             <template v-else>
               <td>{{ m.pricing.search != null ? `$${m.pricing.search.toFixed(4)}` : '—' }}</td>

--- a/apis/audio/index.md
+++ b/apis/audio/index.md
@@ -1,0 +1,15 @@
+# Audio
+
+LibertAI offers text-to-speech (TTS) — turn text into natural speech audio. The API is
+OpenAI-compatible (`/v1/audio/speech`).
+
+- New here? [Usage](./usage.md) covers generating and saving speech audio.
+
+<ModelsPricing category="audio" />
+
+## See also
+
+- [Usage examples](./usage.md) — curl and the OpenAI SDKs
+- [x402 payments](/apis/x402) — pay per request without an API key
+- [Trust model & TEE](/concepts/trust-model) — what the 🔒 flag guarantees
+- [Architecture](/architecture)

--- a/apis/audio/usage.md
+++ b/apis/audio/usage.md
@@ -19,7 +19,7 @@ curl -X POST https://api.libertai.io/v1/audio/speech \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{
-    "model": "kokoro",
+    "model": "kokoro-82m",
     "input": "Hello from LibertAI.",
     "voice": "af_heart",
     "response_format": "wav"
@@ -36,7 +36,7 @@ client = OpenAI(
 )
 
 response = client.audio.speech.create(
-    model="kokoro",
+    model="kokoro-82m",
     input="Hello from LibertAI.",
     voice="af_heart",
     response_format="wav",
@@ -55,7 +55,7 @@ const client = new OpenAI({
 });
 
 const response = await client.audio.speech.create({
-  model: "kokoro",
+  model: "kokoro-82m",
   input: "Hello from LibertAI.",
   voice: "af_heart",
   response_format: "wav",
@@ -70,7 +70,7 @@ fs.writeFileSync("speech.wav", Buffer.from(await response.arrayBuffer()));
 
 | Field | Required | Notes |
 |-------|:--------:|-------|
-| `model` | ✅ | e.g. `kokoro` |
+| `model` | ✅ | e.g. `kokoro-82m` |
 | `input` | ✅ | Text to synthesize (max 8192 characters) |
 | `voice` | — | Raw model voice ID; defaults to the model's default voice (`af_heart` for Kokoro) |
 | `response_format` | — | `wav` only (default) in the current release |

--- a/apis/audio/usage.md
+++ b/apis/audio/usage.md
@@ -1,0 +1,82 @@
+# Usage
+
+Our TTS models expose the OpenAI-compatible [Speech API](https://platform.openai.com/docs/api-reference/audio/createSpeech):
+- `/v1/audio/speech`: synthesize speech audio from input text
+
+This means you can use our TTS models with any of [the OpenAI SDKs](https://platform.openai.com/docs/libraries#install-an-official-sdk) or with any framework that supports custom OpenAI-compatible audio endpoints.
+
+> 💡 Speech is billed on **input characters only**. v1 returns **WAV** audio; pass raw model voice IDs (e.g. `af_heart`) in the `voice` field.
+
+## Examples
+
+### Generate speech
+
+:::tabs
+
+== Shell
+```sh
+curl -X POST https://api.libertai.io/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "kokoro",
+    "input": "Hello from LibertAI.",
+    "voice": "af_heart",
+    "response_format": "wav"
+  }' --output speech.wav
+```
+
+== Python
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.libertai.io/v1",
+    api_key="YOUR_API_KEY",
+)
+
+response = client.audio.speech.create(
+    model="kokoro",
+    input="Hello from LibertAI.",
+    voice="af_heart",
+    response_format="wav",
+)
+response.write_to_file("speech.wav")
+```
+
+== TypeScript
+```ts
+import OpenAI from "openai";
+import fs from "fs";
+
+const client = new OpenAI({
+  baseURL: "https://api.libertai.io/v1",
+  apiKey: "YOUR_API_KEY",
+});
+
+const response = await client.audio.speech.create({
+  model: "kokoro",
+  input: "Hello from LibertAI.",
+  voice: "af_heart",
+  response_format: "wav",
+});
+
+fs.writeFileSync("speech.wav", Buffer.from(await response.arrayBuffer()));
+```
+
+:::
+
+## Parameters
+
+| Field | Required | Notes |
+|-------|:--------:|-------|
+| `model` | ✅ | e.g. `kokoro` |
+| `input` | ✅ | Text to synthesize (max 8192 characters) |
+| `voice` | — | Raw model voice ID; defaults to the model's default voice (`af_heart` for Kokoro) |
+| `response_format` | — | `wav` only (default) in the current release |
+| `speed` | — | 0.25–4.0, default 1.0 |
+
+## See also
+
+- [x402 payments](/apis/x402) — pay per request without an API key
+- [Architecture](/architecture)

--- a/apis/index.md
+++ b/apis/index.md
@@ -1,6 +1,6 @@
 # APIs
 
-LibertAI exposes OpenAI- and Anthropic-compatible APIs for text, image, embeddings, and web search. Each API is
+LibertAI exposes OpenAI- and Anthropic-compatible APIs for text, image, embeddings, audio, and web search. Each API is
 documented with its own models, pricing, and usage examples.
 
 | API | What it does | OpenAI-compat | x402-eligible |
@@ -8,6 +8,7 @@ documented with its own models, pricing, and usage examples.
 | [Text](text/index.md) | Chat completions, completions, Anthropic Messages, function calling, vision, streaming | ✅ | ✅ |
 | [Image](image/index.md) | Stable Diffusion WebUI and OpenAI images endpoints | ✅ | ✅ |
 | [Embeddings](embeddings/index.md) | Text embeddings for semantic search, RAG, clustering | ✅ | ✅ |
+| [Audio](audio/index.md) | Text-to-speech (TTS) with selectable voices | ✅ | ✅ |
 | [Search](search/index.md) | Multi-engine search + URL fetch for RAG | — | ✅ |
 
 ## Authentication


### PR DESCRIPTION
Documents the new `/v1/audio/speech` (TTS) endpoint.

- `apis/audio/index.md` + `usage.md` (curl / Python / TS via the OpenAI SDK, model id `kokoro-82m`)
- Sidebar entry, APIs overview-table row
- `ModelsPricing.vue`: new `audio` category (capabilities + `$X / 1M characters` pricing row)

VitePress build passes. Pairs with the TTS PRs; pricing/voices render from the `LTAI_PRICING` aggregate.